### PR TITLE
 replaced dot (.) with plus (+)

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
       dist: {
         options: {
           environment: 'production',
-          imagesDir: paths.img . '-min',
+          imagesDir: paths.img + '-min',
           force: true
         }
       }


### PR DESCRIPTION
while running grunt I got the following error:

imagesDir: paths.img . '-min',
                       ^^^^^^
Loading "Gruntfile.js" tasks...ERROR

> > SyntaxError: Unexpected string
