### PR TITLE
added compass-options as a dependency due to errors while running grunt

### DIFF
--- a/app/templates/_grunt.package.json
+++ b/app/templates/_grunt.package.json
@@ -1,7 +1,9 @@
 {
   "name": "<%= projectSlug %>",
   "version": "0.0.0",
-  "dependencies": {},
+  "dependencies": {
+    "compass-options": "^0.1.1"
+  },
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-watch": "~0.4.3",


### PR DESCRIPTION
grunt watch

Loading "Gruntfile.js" tasks...ERROR

> > Error: Cannot find module 'compass-options'
